### PR TITLE
Add conditional checks to restrict CI steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
     name: Publish to Market
     runs-on: ubuntu-latest
     needs: build
+    if: github.ref == 'refs/heads/main' && github.actor != 'dependabot[bot]'
     steps:
       - run: mkdir build
 
@@ -165,6 +166,7 @@ jobs:
     name: Pack Linux Binaries
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    if: github.ref == 'refs/heads/main' && github.actor != 'dependabot[bot]'
     env:
       PRODUCT_PLATFORM: "linux"
     steps:


### PR DESCRIPTION
Add conditional checks to restrict CI steps to main branch and non-Dependabot actors